### PR TITLE
New Auth System + Added logout and allowed updating user info

### DIFF
--- a/src/modules/api/auth.ts
+++ b/src/modules/api/auth.ts
@@ -1,12 +1,12 @@
 /**
  * API for authenticating a user on Amethyst.host
  */
-import express                 from 'express';
-import jwt                     from 'jsonwebtoken';
-import argon2, { argon2id }    from 'argon2'
-import { sql }                 from '../sql';
-import { createHash }          from 'crypto';
-import ms                      from 'ms';
+import express                      from 'express';
+import jwt                          from 'jsonwebtoken';
+import argon2, { argon2id }         from 'argon2';
+import { randomBytes, createHash }  from 'crypto';
+import { sql }                      from '../sql';
+import ms                           from 'ms';
 
 export const auth = {
     /**
@@ -21,37 +21,61 @@ export const auth = {
      * const loginToken = await <auth>.login(req, res, account, rememberMe);
      * if (loginToken == 403) return res.sendStatus(403);
      */
-    login: async (req: express.Request, res: express.Response, data: any, rememberMe: boolean) => { // Logging in via amethyst.host
+    login: async (req: express.Request, res: express.Response, data: any, rememberMe: boolean): Promise<any> => { // Logging in via amethyst.host
         const createdIn = parseInt(Date.now().toString().slice(0, -3)) // because for some reason node js decides to use an expanded timestamp
         const ipAddr = req.socket.remoteAddress;
-        const salt = Buffer.alloc((process.env.SALT.length * 2) - 1, process.env.SALT)
-        const verifiedHash = await argon2.verify(data.password, req.body.password, {
-                                           type: argon2id,
-                                           salt: salt,
-                                           secret: Buffer.from(data.salt, 'hex')
-                                          })
+        const verifiedHash = await auth.verifyPassword(req.body.password, data)
         if (!verifiedHash) return 403;
+        
         const userData = { email: data.email, name: data.name, id: data.user_id, permission_id: data.permission_id }
-        const accessTokenOpts = sql.jwtOptions
-        let expiresIn = ms('1h')
+        const refreshTokenOpts = JSON.parse(JSON.stringify(sql.RTOptions));
+        let expiresIn = ms('7 days')
         if (rememberMe) {
             expiresIn = ms('90 days')
         }
         expiresIn = parseInt(expiresIn.toString().slice(0, -3))
-        accessTokenOpts.expiresIn = expiresIn
-        const accessToken = jwt.sign(userData, process.env.ACCESS_TOKEN, accessTokenOpts); // Will implement Refresh Token soon
+        refreshTokenOpts.expiresIn = expiresIn
+        const refreshToken = auth.genToken({ id: userData.id }, refreshTokenOpts, "refresh");
+        const accessToken = auth.genToken(userData, null, "access");
         const ip = createHash('sha256').update(ipAddr).digest('hex'); // Convert IP address to SHA256 hash
         expiresIn = expiresIn + createdIn;
-        sql.db.prepare("INSERT INTO sessions (user_id, jwt, createdIn, expiresIn, ip) VALUES (?, ?, ?, ?, ?)").run(userData.id, accessToken, createdIn, expiresIn, ip) // Adds the token to DB in case the user decides to logout.
-        return { email: data.email, accessToken: accessToken, expiresIn: expiresIn };
+        sql.db.prepare("INSERT INTO sessions (user_id, jwt, createdIn, expiresIn, ip) VALUES (?, ?, ?, ?, ?)").run(userData.id, refreshToken, createdIn, expiresIn, ip) // Adds the token to DB in case the user decides to logout.
+        return { email: data.email, refreshToken, accessToken, expiresIn: expiresIn };
     },
-    setCookie: async (req: express.Request, res: express.Response, value: string, expiresIn: number): Promise<boolean> => {
-        res.cookie('jwt', value, { secure: true, httpOnly: true, maxAge: expiresIn, sameSite: 'strict' }); // Client Side wont access this because httpOnly.
+    setCookie: async (res: express.Response, name: string, value: string, expiresIn: number): Promise<boolean> => {
+        res.cookie(name, value, { secure: true, httpOnly: true, maxAge: expiresIn, sameSite: 'strict' }); // Client Side wont access this because httpOnly.
         return true;
     },
-    getUserData: async (req: express.Request, res: express.Response): Promise<any> => {
+    verifyPassword: async (password: string, data: any): Promise<boolean> => {
+        const salt = Buffer.alloc((process.env.SALT.length * 2) - 1, process.env.SALT)
+        return await argon2.verify(data.password, password, {
+            type: argon2id,
+            salt: salt,
+            secret: Buffer.from(data.salt, 'hex')
+        })
+    },
+    setPassword: async (password: string): Promise<Record<string, unknown>> => {
+        const MIN_PASS_LENGTH = 6; // Minimum password length
+        const SECRET_LENGTH = 32;
+
+        if (MIN_PASS_LENGTH > password.length) return { result: 406 }
+        const userSalt = randomBytes(SECRET_LENGTH);
+        const salt = Buffer.alloc((process.env.SALT.length * 2) - 1, process.env.SALT)
+        const hashedPass = await argon2.hash(password, {type: argon2id, salt: salt, secret: userSalt});
+        return { 
+            password: hashedPass,
+            salt: userSalt.toString('hex')
+        }
+    },
+    getUserData: async (req: express.Request, res: express.Response): Promise<Record<string, any> | boolean | number> => { // so ESLint can stop complaining
         if (req.cookies.jwt) {
-            const verifyToken = await auth.verifyToken(req, res, false, false)
+            let verifyToken = await auth.verifyToken(req, res, false, "both")
+            if (verifyToken == 101) {
+                const newAccessToken = await auth.regenAccessToken(req, res);
+                if (typeof newAccessToken != "string") return false;
+                verifyToken = await auth.verifyToken(req, res, false, "both")
+                return verifyToken;
+            }
             if (verifyToken && verifyToken["accessToken"]) {
                 return verifyToken;
             } else {
@@ -61,17 +85,51 @@ export const auth = {
             return false;
         }
     },
-    updateJWT: async (req: express.Request, res: express.Response): Promise<boolean> => { // Wont be used until I implement Refresh Tokens
-        if (req.cookies.jwt) {
-            const verifyToken = await auth.verifyToken(req, res, false, false)
-            if (verifyToken && verifyToken["accessToken"]) {
-                const account = await sql.db.prepare("SELECT user_id, name, email, password, salt, verified, permission_id FROM users WHERE user_id = ?")
-                                            .get(verifyToken["user_id"]);
-                if (!account) return false;
 
-            } else {
-                return false;
+    // this is why typescript is better than javascript, else you would have to do a bunch of if checks, and its more readable
+    /**
+     * Generates a token
+     * @param {Object} data Data for what should be in the JWT Token.
+     * @param {Object | null} opts Options for JWT
+     * @param {"refresh" | "access"} type If it is a Refresh Token or an Access Token that should be generated 
+     * @returns {string}
+     * 
+     * @example
+     * const accessToken = <auth>.genToken(userData, null, "access");
+     * return accessToken;
+     */
+    genToken: (data: Record<string, unknown>, opts: Record<string, unknown> | null, type: "refresh" | "access"): string => { // Wont be used until I implement Refresh Tokens
+        switch (type) {
+            case "refresh": // Refresh Token
+                return jwt.sign(data, process.env.REFRESH_TOKEN, opts);
+            case "access": { // Access Token
+                const opts = JSON.parse(JSON.stringify(sql.ATOptions)); // Prevent mutation, because javascript likes to edit the object from sql.ts instead of the actual variable
+                const expiryDate = parseInt(opts.expiresIn.toString().slice(0, -3));
+                opts.expiresIn = expiryDate
+                return jwt.sign(data, process.env.ACCESS_TOKEN, opts);
             }
+        }
+    },
+    regenAccessToken: (req: express.Request, res: express.Response): string | number => {
+        const verifyToken = auth.verifyToken(req, res, false, "refresh")
+        if (typeof verifyToken != "object") return verifyToken;
+        const data = sql.db.prepare("SELECT user_id, name, email, password, salt, verified, permission_id FROM users WHERE user_id = ?")
+                           .get(verifyToken["user_id"]);
+        if (!data) return 404;
+        const userData = { email: data.email, name: data.name, id: data.user_id, permission_id: data.permission_id }
+        const accessToken = auth.genToken(userData, null, "access");
+        const expiresIn = parseInt((ms("1h") + Date.now()).toString().slice(0, -3));
+        auth.setCookie(res, "access_token", accessToken, expiresIn);
+        req.cookies["access_token"] = accessToken;
+        return accessToken;
+    },
+    updateAccessToken: async (req: express.Request, res: express.Response): Promise<Record<string, any> | boolean> => { // This was required because updating user data would require JWT access token to be updated, as it would just remain the same old information
+        if (req.cookies.jwt) {
+            const newAccessToken = auth.regenAccessToken(req, res)
+            if (typeof newAccessToken != "string") return false;
+            const verifyToken = await auth.verifyToken(req, res, false, "access")
+            if (typeof verifyToken != "object") return false
+            return verifyToken;
         } else {
             return false;
         }
@@ -88,56 +146,76 @@ export const auth = {
      * const userData = await <auth>.verifyToken(req, res, false, false); // Request, Response, sendResponse (False), useAuthorization (False).
      * if (typeof userData != "object") return res.sendStatus(userData); // If its not an object. (Could be either undefined or number.)
      */
-    verifyToken: (req: express.Request, res: express.Response, sendResponse: boolean, useAuthorization: boolean): any => { // Probably not a good idea to do this, as most people use next()
+    verifyToken: (req: express.Request, res: express.Response, sendResponse: boolean, type: "access" | "refresh" | "both"): express.Response | number | Record<string, unknown> => { // Probably not a good idea to do this, as most people use next()
         const currentDate = parseInt(Date.now().toString().slice(0, -3))
-        let authorization;
-        let token;
-        if (useAuthorization) {
-            authorization = req.headers['Authorization'] || req.headers['authorization'];
-            if (authorization) {
-                token = authorization.split(' ')[1];
-            }
-        } else {
-            authorization = req.cookies.jwt
-            token = authorization
-        }
-        if (!authorization) return (sendResponse) ? res.sendStatus(403) : 403;
-        const tokenValid = jwt.verify(token, process.env.ACCESS_TOKEN, sql.jwtOptions)
-        if (!tokenValid) return (sendResponse) ? res.sendStatus(403) : 403; // Forbidden.
-        //if (tokenValid.id != user_id && useAuthorization) return (sendResponse) ? res.sendStatus(403) : 403; // Forbidden
-        const ip = createHash('sha256').update(req.ip).digest('hex');
-        const tokenInDB = sql.db.prepare('SELECT user_id FROM sessions WHERE user_id = ? AND jwt = ? AND expiresIn > ? AND ip = ?').pluck().all(tokenValid.id, token, currentDate, ip);
-        if (!tokenInDB.length) return (sendResponse) ? res.sendStatus(403) : 403;
-        if (tokenValid.exp < currentDate) return (sendResponse) ? res.sendStatus(403) : 403;
-        const userExists = sql.db.prepare('SELECT count(*) FROM users WHERE user_id = ?').pluck().get(tokenValid.id);
-        if (!userExists) return (sendResponse) ? res.sendStatus(404) : 404;
-        //res.setHeader('Authorization', 'Bearer ' + tokenValid)
-        const response = { accessToken: token, user_id: tokenInDB[0], name: tokenValid.name, email: tokenValid.email, permission_id: tokenValid.permission_id }
-        return (sendResponse) ? res.status(200).json(response) : response;
-    },
-    discord: async (data) => { // Authenticating with Discord
+        const accessToken = req.cookies.access_token;
+        const refreshToken = req.cookies.jwt;
+        const forbidden = () => (sendResponse) ? res.sendStatus(403) : 403;
+        if (!accessToken || !refreshToken) return forbidden()
+        if (!accessToken && !refreshToken && type == "both") return forbidden()
+        let user_id: string;
 
-    },
-    deleteSession: async (req: express.Request, res: express.Response) => {
-        if (req.cookies.jwt) {
-            const verifyToken = await auth.verifyToken(req, res, false, false)
-            if (verifyToken && verifyToken["accessToken"]) {
-                return sql.db.prepare('DELETE FROM sessions WHERE user_id = ?').run(verifyToken.user_id);
-            } else {
-                return false;
+        let refreshTokenValid;
+
+        let tokenInDB: Array<number>;
+
+        if (["refresh", "both"].includes(type)) {
+            try {
+                refreshTokenValid = jwt.verify(refreshToken, process.env.REFRESH_TOKEN, sql.RTOptions)
+                if (!refreshTokenValid) return forbidden() // Forbidden.
+                const ip = createHash('sha256').update(req.ip).digest('hex');
+                tokenInDB = sql.db.prepare('SELECT user_id FROM sessions WHERE user_id = ? AND jwt = ? AND expiresIn > ? AND ip = ?')
+                                .pluck().all(refreshTokenValid.id, refreshToken, currentDate, ip);
+                if (!tokenInDB.length) return forbidden()
+                if (refreshTokenValid.exp < currentDate) return forbidden()
+                user_id = refreshTokenValid.id
+            } catch (e) {
+                console.error(e)
+                return (sendResponse) ? res.sendStatus(401) : 401;
             }
-        } else {
-            return false;
+            
         }
+        let accessTokenValid;
+        if (["access", "both"].includes(type)) {
+            try {
+                accessTokenValid = jwt.verify(accessToken, process.env.ACCESS_TOKEN, sql.ATOptions)
+                if (!accessTokenValid) return (sendResponse) ? res.sendStatus(403) : 101; // Forbidden, 101 for allowing me to know if it needs to generate an Access Token.
+                user_id = accessTokenValid.id;
+            } catch (e) {
+                console.error(e)
+                return (sendResponse) ? res.sendStatus(401) : 101;
+            }
+        }
+        if (type == "both") {
+            if (refreshTokenValid.id != accessTokenValid.id) return forbidden() // Forbidden.
+        }
+         
+        const userExists = sql.db.prepare('SELECT count(*) FROM users WHERE user_id = ?')
+                                 .pluck().get(user_id);
+        if (!userExists) return (sendResponse) ? res.sendStatus(404) : 404;
+        let response = {};
+        switch (type) {
+            case "both":
+                response = { refreshToken, accessToken, user_id: tokenInDB[0], name: accessTokenValid.name, email: accessTokenValid.email, permission_id: accessTokenValid.permission_id }
+                break;
+            case "refresh":
+                response = { refreshToken, user_id: tokenInDB[0] }
+                break;
+            case "access":
+                response = { accessToken, user_id: user_id, name: accessTokenValid.name, email: accessTokenValid.email, permission_id: accessTokenValid.permission_id }
+                break;
+        }
+
+        return (sendResponse) ? res.status(200).json(response) : response;
     }
 }
 export const prop = {
     name: "auth",
     desc: "Authenticates a user (Logging in)",
-    run: async (req: express.Request, res: express.Response) => {
+    run: async (req: express.Request, res: express.Response): Promise<unknown> => {
         res.set("Allow", "POST"); // To give the method of whats allowed
         if (req.method != "POST") return res.sendStatus(405) // If the request isn't POST then respond with Method not Allowed.
-        if(!req.cookies.jwt){
+        if (req.cookies.jwt) return res.status(403).send("Already authenticated.")
         const { email, password, rememberMe } = req.body;
         if ([email, password].includes(undefined)) return res.status(406)
                                                                     .send("Please enter in an Email, and Password.");
@@ -146,10 +224,9 @@ export const prop = {
         if (!account) return res.sendStatus(404); // User doesn't exist.
         const loginToken = await auth.login(req, res, account, rememberMe);
         if (loginToken == 403) return res.sendStatus(403);
-        auth.setCookie(req, res, loginToken.accessToken, loginToken.expiresIn);
+        auth.setCookie(res, "jwt", loginToken.refreshToken, loginToken.expiresIn);
+        auth.setCookie(res, "access_token", loginToken.accessToken, loginToken.expiresIn);
+        
         res.json(loginToken)
-        }else{
-            auth.deleteSession(req, res);
-        }
     }
 }

--- a/src/modules/api/mail.ts
+++ b/src/modules/api/mail.ts
@@ -23,7 +23,12 @@ export const prop = {
     run: async (req: express.Request, res: express.Response): Promise<any> => {
         res.set("Allow", "POST"); // To give the method of whats allowed
         if (req.method != "POST") return res.sendStatus(405) // If the request isn't a POST request, then respond with Method not Allowed.
-        const userData = await auth.verifyToken(req, res, false, false);
+        let userData = await auth.verifyToken(req, res, false, "both");
+        if (userData == 101) {
+            const newAccessToken = await auth.regenAccessToken(req, res);
+            if (typeof newAccessToken != "string") return false;
+            userData = await auth.verifyToken(req, res, false, "both")
+        }
         if (typeof userData != "object") return res.sendStatus(userData);
         if (!permissions.hasPermission(userData['permission_id'], `/mail`)) return res.sendStatus(403); // If you want anyone to be able to use the mail, comment this out.
         const { subject, content, email } = req.body;

--- a/src/modules/api/tickets.ts
+++ b/src/modules/api/tickets.ts
@@ -55,7 +55,12 @@ export const prop = {
         const params = req.params[0].split("/").slice(1); // Probably a better way to do this in website.ts via doing /api/:method/:optionalparam*? but it doesnt work for me.
         res.set("Allow", allowedMethods.join(", ")); // To give the method of whats allowed
         if (!allowedMethods.includes(req.method)) return res.sendStatus(405) // If the request isn't included from allowed methods, then respond with Method not Allowed.
-        const userData = await auth.verifyToken(req, res, false, false) //true
+        let userData = await auth.verifyToken(req, res, false, "both") //true
+        if (userData == 101) {
+            const newAccessToken = await auth.regenAccessToken(req, res);
+            if (typeof newAccessToken != "string") return false;
+            userData = await auth.verifyToken(req, res, false, "both")
+        }
         if (typeof userData != "object") return res.sendStatus(userData);
         const timestamp = Date.now();
         let paramName = params[0]

--- a/src/modules/api/user.ts
+++ b/src/modules/api/user.ts
@@ -1,0 +1,94 @@
+/**
+ * API for Users on Ametrine.host
+ */
+ import express                 from 'express';
+ import { sql }                 from '../sql';
+ import { auth }                from './auth';
+ 
+ function allowedMethod(req: express.Request, res: express.Response, type: Array<string>): boolean { // I should probably turn this into a global function instead of copying & pasting all over the place.
+    res.set("Allow", type.join(", "));
+    if (!type.includes(req.method)) {
+        res.sendStatus(405);
+        return false;
+    }
+    return true;
+}
+export const prop = {
+    name: "user",
+    desc: "API for users.",
+    run: async (req: express.Request, res: express.Response) => {
+        // Copy & Paste from tickets.ts hA
+        const allowedMethods = ["GET", "POST", "PATCH", "PUT", "DELETE"];
+        const params = req.params[0].split("/").slice(1); // Probably a better way to do this in website.ts via doing /api/:method/:optionalparam*? but it doesnt work for me.
+        res.set("Allow", allowedMethods.join(", ")); // To give the method of whats allowed
+        if (!allowedMethods.includes(req.method)) return res.sendStatus(405) // If the request isn't included from allowed methods, then respond with Method not Allowed.
+        let userData = await auth.verifyToken(req, res, false, "access");
+        if (userData == 101) {
+            const newAccessToken = await auth.regenAccessToken(req, res);
+            if (typeof newAccessToken != "string") return false;
+            userData = await auth.verifyToken(req, res, false, "both")
+        }
+        if (typeof userData != "object") return res.sendStatus(userData);
+        if (!userData["accessToken"]) return res.sendStatus(403); // Forbidden due to having the incorrect response. Probably will never happen unless the users JWT is REALLY weird
+        let paramName = params[0]
+        if (!paramName) {
+            paramName = ""
+        }
+        switch (paramName) {
+            case "logout": { // Logs out a user.
+                if (allowedMethod(req, res, ["POST"])) {
+                    sql.db.prepare('DELETE FROM sessions WHERE user_id = ? AND jwt = ?')
+                          .run(userData["user_id"], userData, userData["accessToken"]);
+                    res.clearCookie('jwt'); // Use this next time for clearing cookies, as using document.cookie via JS wont work due to the cookie being httpOnly.
+                    res.clearCookie('access_token')
+                    return res.sendStatus(200); // OK
+                }
+                break;
+            }
+            case "2fa": { // Enables 2FA (currently not made yet)
+                break;
+            }
+            case "": {
+                if (allowedMethod(req, res, ["DELETE", "PUT"])) {
+                    switch (req.method) {
+                        case "PUT": { // Updating user data, such as first name, email, password, etc
+                            const { name, email, password } = req.body;
+                            if (!name && !email && !password) return res.sendStatus(406) // If nothing is provided, or invalid body was provided, bye.
+                            let updated = false;
+                            if (name && name.length && name != userData["name"]) {
+                                await sql.db.prepare('UPDATE users SET name = ? WHERE user_id = ?').run(name, userData["user_id"]);
+                                updated = true;
+                            }
+                            if (email && email.length && email != userData["email"]) {
+                                await sql.db.prepare('UPDATE users SET email = ? WHERE user_id = ?').run(email, userData["user_id"]);
+                                updated = true;
+                            }
+                            if (password && password.length) { // Would really want to implement a ratelimit soon, since this could easily stress our servers.
+                                const user = await sql.db.prepare('SELECT password, salt FROM users WHERE user_id = ?').get(userData["user_id"]);
+                                if (!user) return res.sendStatus(404);
+                                const passResult = await auth.setPassword(password);
+                                if (passResult.result && passResult.result == 406) return res.status(406)
+                                                                                             .send("Password must not be less than 6 characters.");
+                                const verifyHash = await auth.verifyPassword(password, user);
+                                if (verifyHash) return res.status(403).send("You can't change it to the same password.");
+                                
+                                await sql.db.prepare('UPDATE users SET password = ?, salt = ? WHERE user_id = ?').run(passResult.password, passResult.salt, userData["user_id"]);
+                                updated = true;
+                            }
+                            if (!updated) return res.sendStatus(202);
+                            await auth.regenAccessToken(req, res);
+                            return res.sendStatus(200);
+                        }
+                        case "DELETE": // Deletes the account.
+
+                            break;
+                    }
+                }
+                break;
+            }
+            default:
+                return res.sendStatus(404)
+        }
+        
+    }
+}

--- a/src/modules/sql.ts
+++ b/src/modules/sql.ts
@@ -1,10 +1,15 @@
 import Database from 'better-sqlite3';
 
 import ms       from 'ms';
+
 export const sql = {
     db: new Database('./data/db/database.db', { verbose: console.log }),
-    jwtOptions: {
+    RTOptions: { // Refresh Token Options
         expiresIn: ms('90 days'),
+        issuer: "Amethyst Host (1.0)"
+    },
+    ATOptions: { // Access Token Options
+        expiresIn: ms('1h'),
         issuer: "Amethyst Host (1.0)"
     }
 }

--- a/src/modules/views/billing/html/index.eta
+++ b/src/modules/views/billing/html/index.eta
@@ -114,7 +114,7 @@
             <div>
                 <button class=" collapsible">Account Details & Options</button>
                 <div class="content">
-                    <form>
+                    <form id="updateForm">
                         <fieldset>
                             <label for="main-full-name">Full Name</label>
                             <input spellcheck="false" type="text" name="main-full-name" id="main-full-name"

--- a/src/modules/views/billing/js/auth.js
+++ b/src/modules/views/billing/js/auth.js
@@ -19,6 +19,9 @@ const loginUser = async (user) => {
                 break;
         }
         loginError.innerHTML = `${exclamationCircle} ${errorText}`;
+        setTimeout(function() {
+            loginError.innerHTML = ''
+        }, 3000)
         console.error(e);
     }
 }
@@ -41,21 +44,31 @@ const registerUser = async (user) => {
                 break;
         }
         regError.innerHTML = `${exclamationCircle} Error: ${errorText}`;
+        setTimeout(function() {
+            regError.innerHTML = ''
+        }, 3000)
         console.error(e);
     }
 }
 
 const logOut = async () => {
-    const url = "/api/auth"
+    const url = "/api/user/logout"
     try {
-        document.cookie = 'jwt=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-        localStorage.removeItem('jwt')
-        sessionStorage.removeItem('jwt')
         const response = await axios.post(url);
         console.log(response)
-        setTimeout(() => {
-            location.reload();
-        }, 1000);
+        window.scrollTo(0,0) // So users wont have to scroll back up, you can remove this if you want to.
+        location.reload();
+    } catch (e) {
+        console.log(e);
+    }
+}
+
+const updateUser = async (user) => {
+    const url = "/api/user"
+    try {
+        const response = await axios.put(url, user);
+        console.log(response)
+        if (response.status == 200) location.reload();
     } catch (e) {
         console.log(e);
     }
@@ -63,8 +76,9 @@ const logOut = async () => {
 
 function onLoad() {
     const loginForm = document.querySelector("#loginForm");
-    const registerForm = document.querySelector('#registerForm')
-    const logOutButton = document.querySelector('#logOutButton')
+    const registerForm = document.querySelector('#registerForm');
+    const updateForm = document.querySelector('#updateForm');
+    const logOutButton = document.querySelector('#logOutButton');
     loginForm.addEventListener('submit', event => {
         event.preventDefault();
         const email = loginForm.querySelector('div > #login-email').value;
@@ -87,6 +101,15 @@ function onLoad() {
             name,
             email,
             password,
+        });
+    });
+    updateForm.addEventListener('submit', event => {
+        event.preventDefault();
+        const name = updateForm.querySelector('#main-full-name').value;
+        const email = updateForm.querySelector('#main-email').value;
+        updateUser({
+            name,
+            email,
         });
     });
     try {

--- a/src/modules/website.ts
+++ b/src/modules/website.ts
@@ -51,7 +51,8 @@ app.use(
         "style-src": ["'self'", "'unsafe-inline'", "unpkg.com", "fonts.googleapis.com", "*.gstatic.com", "use.fontawesome.com", "fontawesome.com"],
         "script-src-attr": ["'self'", "'unsafe-inline'"]
       }
-    }
+    },
+    xssFilter: true
   }
 ));
 

--- a/src/sql/init.sql
+++ b/src/sql/init.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS invoices (
 CREATE TABLE IF NOT EXISTS sessions (
   session_id  INTEGER   NOT NULL PRIMARY KEY, -- Session ID
   user_id     INTEGER   NOT NULL,             -- User ID
-  jwt         TEXT      NOT NULL,             -- JWT token
+  jwt         TEXT      NOT NULL,             -- JWT token (Refresh Token)
   createdIn   TIMESTAMP NOT NULL,             -- When the Token was created
   expiresIn   TIMESTAMP NOT NULL,             -- When the token expires
   ip          TEXT      NOT NULL,             -- Remote Address


### PR DESCRIPTION
What this pull request adds is a short revamp on the authentication system, as it adds a `Refresh Token`.

`Refresh Tokens` are used to refresh `Access Tokens`, that way if a users permissions were updated or their info was updated, it can be updated without having to always check the database on the user info.

`Access Tokens` usually expire in an hour but can be changed. It's recommended to keep the time short though.

This PR also adds a new endpoint, which is `/api/user`. This allows the user to be able to update their info, such as email, name, and password.

You can also delete the session or logout by doing a `POST` request to `/api/user/logout`. This is also added in the billing page where you can logout.

I've also fixed a bug where if a JWT token was expired, it crashes the server unless its restarted.

If there are any bugs with this PR, please let me know so I can fix them.