### PR TITLE
Added new API endpoints + Updated API endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,10 @@
         "mailparser": "^3.2.0",
         "morgan": "^1.10.0",
         "ms": "^2.1.2",
+        "node-fetch": "^2.6.1",
         "nodemailer": "^6.5.0",
-        "smtp-server": "^3.9.0"
+        "smtp-server": "^3.9.0",
+        "stripe": "^8.167.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.12",
@@ -287,8 +289,7 @@
     "node_modules/@types/node": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
-      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
-      "dev": true
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.6",
@@ -3324,6 +3325,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "8.167.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.167.0.tgz",
+      "integrity": "sha512-iWrof4zc/TRjzKr181Tj5Tz/RaxpNQjqkkVjjfqmzXuSY1tNV4HTbS26ucsBNkw2MJZr/q1Hx8gWDRdhZ8FG2g==",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.6.0"
+      },
+      "engines": {
+        "node": "^8.1 || >=10.*"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3911,8 +3924,7 @@
     "@types/node": {
       "version": "15.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
-      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
-      "dev": true
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
     },
     "@types/qs": {
       "version": "6.9.6",
@@ -6177,6 +6189,15 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "stripe": {
+      "version": "8.167.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.167.0.tgz",
+      "integrity": "sha512-iWrof4zc/TRjzKr181Tj5Tz/RaxpNQjqkkVjjfqmzXuSY1tNV4HTbS26ucsBNkw2MJZr/q1Hx8gWDRdhZ8FG2g==",
+      "requires": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.6.0"
+      }
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "mailparser": "^3.2.0",
     "morgan": "^1.10.0",
     "ms": "^2.1.2",
+    "node-fetch": "^2.6.1",
     "nodemailer": "^6.5.0",
-    "smtp-server": "^3.9.0"
+    "smtp-server": "^3.9.0",
+    "stripe": "^8.167.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.12",

--- a/src/modules/api/announcements.ts
+++ b/src/modules/api/announcements.ts
@@ -1,0 +1,90 @@
+/**
+ * API for Showing announcements (or posting)
+ */
+import express                 from 'express';
+import { sql }                 from '../sql';
+import { permissions }         from '../permissions'
+import { auth }                from './auth';
+
+function encode_base64(str) {
+    if (!str.length) return false;
+        return btoa(encodeURIComponent(str));
+}
+function decode_base64(str) {
+    if (!str.length) return false;
+        return decodeURIComponent(atob(str));
+}
+
+export const prop = {
+     name: "announcements",
+     desc: "API for Announcements",
+     run: async (req: express.Request, res: express.Response): Promise<any> => {
+        const allowedMethods = ["GET", "POST", "DELETE"];
+        res.set("Allow", allowedMethods.join(", ")); // To give the method of whats allowed
+        if (!allowedMethods.includes(req.method)) return res.sendStatus(405);
+        const params = req.params[0].split("/").slice(1);
+        let userData = await auth.verifyToken(req, res, false, "both");
+        if (userData == 101) {
+            const newAccessToken = await auth.regenAccessToken(req, res);
+            if (typeof newAccessToken != "string") return false;
+            userData = await auth.verifyToken(req, res, false, "both")
+        }
+        if (typeof userData != "object" && req.method != "GET") return res.sendStatus(userData);
+        switch (req.method) {
+            case "GET": { // Fetching the latest announcement.
+                let type = req.query.type; // Announcement Type
+                if (!type) type = "null";
+                if (!["outage", "news", "warning", "null"].includes(type.toString().toLowerCase())) return res.sendStatus(406);
+                const params: Array<any> = [Date.now()]; // ESLint wont stop complaining about this.
+                let query = "SELECT announcementText, showToCustomersOnly, announcementType FROM announcements WHERE deleteIn > ?";
+                if (type != "null") {
+                    query += " AND announcementType = ?"
+                    params.push(type);
+                } else if (typeof userData != "object") {
+                    query += " AND showToCustomersOnly = 0"
+                }
+                const announcements = await sql.db.prepare(query).all(params);
+                if (!announcements.length) return res.sendStatus(404); // Announcement not found
+                if (announcements.showToCustomersOnly && typeof userData != "object") return res.sendStatus(403); // Forbidden from viewing announcement.
+                return res.status(200).json(announcements.map(announcement => {
+                    announcement.announcementText = decode_base64(announcement.announcementText);
+                    return announcement;
+                }));
+            }
+            case "POST": { // For creating an announcement.
+                if (!permissions.hasPermission(userData['permission_id'], `/announcements`)) return res.sendStatus(403);
+                const announcement = req.body.text; // Announcement Text
+                const type = req.body.type; // Announcement Type
+                let deleteOn = req.body.deleteOn; // When to delete the announcement
+                let showCustomers = req.body.showToCustomersOnly; // If it should only show to customers
+                deleteOn = parseInt(deleteOn);
+                if (!announcement && !type && !deleteOn && !showCustomers) return res.sendStatus(406);
+                if (!["outage", "news", "warning"].includes(type.toString())) return res.status(406).send("Invalid type");
+                const currentDate = Date.now();
+                if (deleteOn < currentDate) return res.status(406).send(`Invalid Timestamp (Cannot be higher than ${currentDate})`);
+                if (isNaN(deleteOn)) return res.status(406).send("Invalid Timestamp")
+                if (!["0","1","true","false"].includes(showCustomers.toString())) return res.status(406).send("Show Customers must be true or false.")
+                switch (showCustomers.toString()) {
+                    case "true": showCustomers = 1; break;
+                    case "false": showCustomers = 0; break;
+                }
+                await sql.db.prepare(`INSERT INTO announcements
+                                    (announcementType, announcementText, deleteIn, showToCustomersOnly) VALUES
+                                    (?, ?, ?, ?)`).run(type, encode_base64(announcement), deleteOn, showCustomers);
+                const getAnnouncementID = await sql.db.prepare('SELECT announcement_id FROM announcements WHERE deleteIn = ? AND announcementType = ? AND announcementText = ?')
+                                                      .get(deleteOn, type, encode_base64(announcement));
+                if (!getAnnouncementID) return res.sendStatus(204);
+                return res.status(200).json(getAnnouncementID)
+            }
+            case "DELETE": { // For deleting an announcement.
+                if (!permissions.hasPermission(userData['permission_id'], `/announcements`)) return res.sendStatus(403);
+                const id = req.query.type;
+                if (!id) return res.sendStatus(406);
+                const findAnnouncement = sql.db.prepare('SELECT count(*) FROM announcements WHERE announcement_id = ?').pluck().get(id);
+                if (!findAnnouncement) return res.sendStatus(404); // Announcement not found.
+                await sql.db.prepare('DELETE FROM announcements WHERE announcement_id = ?').run(id);
+                return res.sendStatus(204);
+            }
+        }
+    }
+}

--- a/src/modules/views/billing/html/cancel.eta
+++ b/src/modules/views/billing/html/cancel.eta
@@ -1,0 +1,1 @@
+Cancel Page

--- a/src/modules/views/billing/html/order.eta
+++ b/src/modules/views/billing/html/order.eta
@@ -95,7 +95,7 @@
             </form>
         </div>
         <div>
-            <form>
+            <form action="/api/order/checkout" method="POST">
             <p>Coupons & Checkout</p>
                 <fieldset class="coupon">
                     <label>Coupon code<span class="tooltip">?<span class="tooltiptext">Apply discount codes to get even better deals!</span></span></label>
@@ -110,7 +110,10 @@
                 <p class="small">Recurring Amount: €<span class="fullPrice recurring"><%=it.details.price%></span></p>
                 <p class="price">Due Today: €<span class="fullPrice"><%=it.details.price%></span></p>
                 <p class="small">+ VAT calculated at checkout*</p>
-                <a id="checkout">Checkout with Stripe</a>
+                <!--<form action="/api/order/redirect" method="POST">-->
+                    <!--<a id="checkout">Checkout with Stripe</a>-->
+                    <button id="checkout" type="submit">Checkout with Stripe</button>
+                <!--</form>-->
             </form>
         </div>
     </main>

--- a/src/modules/views/billing/html/success.eta
+++ b/src/modules/views/billing/html/success.eta
@@ -1,0 +1,1 @@
+Success Page

--- a/src/modules/views/billing/js/auth.js
+++ b/src/modules/views/billing/js/auth.js
@@ -100,7 +100,8 @@ function onLoad() {
         registerUser({
             name,
             email,
-            password,
+            password//,
+            //"g-recaptcha-response": grecaptcha.getResponse()
         });
     });
     try{

--- a/src/modules/website.ts
+++ b/src/modules/website.ts
@@ -8,7 +8,6 @@ import config       from "../config.json";
 import { util }     from "../util";
 import { Endpoint } from "../types/endpoint";
 import helmet       from "helmet"
-import bodyParser   from "body-parser"
 import cookieParser from "cookie-parser"
 import { auth }     from "./api/auth"
 import * as plans from "../plans.json"
@@ -36,9 +35,10 @@ app.use(morgan("[express]\t:method :url :status :res[content-length] - :response
 app.use(express.static(path.join(__dirname, "views")));
 
 // Create Parse for application/x-www-form-urlencoded
-app.use(bodyParser.urlencoded({ extended: false })) // Required for req.body
+app.use(express.urlencoded({ extended: false })) // Required for req.body
+app.use('/api/order/webhook', express.raw({type: 'application/json'}));
 // Create Parse for application/json
-app.use(bodyParser.json())
+app.use(express.json())
 // Create Parse for Cookies
 
 // Using Helmet to mitigate common security issues via setting HTTP Headers, such as XSS Protect and setting X-Frame-Options to sameorigin, meaning it'll prevent iframe attacks
@@ -47,8 +47,8 @@ app.use(
     contentSecurityPolicy: {
       useDefaults: true, // nonce when
       directives: {
-        defaultSrc: ["'self'"],
-        "script-src": ["'self'", "'unsafe-inline'", "static.cloudflareinsights.com", "unpkg.com", "cdn.jsdelivr.net", "ajax.googleapis.com", "*.gstatic.com", "pixijs.download", "'unsafe-eval'"], // unsafe eval worst idea, pixijs why do you have this
+        defaultSrc: ["'self'", "www.recaptcha.net"],
+        "script-src": ["'self'", "'unsafe-inline'", "static.cloudflareinsights.com", "unpkg.com", "www.recaptcha.net", "cdn.jsdelivr.net", "ajax.googleapis.com", "*.gstatic.com", "js.stripe.com", "pixijs.download", "'unsafe-eval'"], // unsafe eval worst idea, pixijs why do you have this
         "style-src": ["'self'", "'unsafe-inline'", "unpkg.com", "fonts.googleapis.com", "*.gstatic.com", "use.fontawesome.com", "fontawesome.com"],
         "script-src-attr": ["'self'", "'unsafe-inline'"]
       }

--- a/src/permissions.json
+++ b/src/permissions.json
@@ -15,7 +15,7 @@
         "accessAPI": ["/tickets", "/tickets/create", "/tickets/list", "/tickets/:ticketid", "/mail"]
     },
     "4": {
-        "accessAPI": ["/tickets", "/tickets/create", "/tickets/list", "/tickets/:ticketid", "/tickets/:ticketid/delete", "/mail"]
+        "accessAPI": ["/tickets", "/tickets/create", "/tickets/list", "/tickets/:ticketid", "/tickets/:ticketid/delete", "/mail", "/announcements"]
     }
     
 }

--- a/src/sql/init.sql
+++ b/src/sql/init.sql
@@ -67,3 +67,12 @@ CREATE TABLE IF NOT EXISTS coupons (
   forever      INTEGER   NOT NULL DEFAULT 0,          -- If this coupon should apply in reoccuring payments or not. (0 = False | 1 = True)
   createdIn    TIMESTAMP NOT NULL                     -- When the coupon was created
 );
+
+CREATE TABLE IF NOT EXISTS announcements (
+  announcement_id      INTEGER   NOT NULL PRIMARY KEY,              -- Announcement ID.
+  announcementType     TEXT      NOT NULL DEFAULT 'news',           -- Announcement Type ("outage", "news", "warning")
+  announcementText     TEXT      NOT NULL DEFAULT 'Announcement',   -- What the text should show
+  deleteIn             TIMESTAMP NOT NULL,                          -- When the announcement should be deleted (or invalid)
+  showToCustomersOnly  INTEGER   NOT NULL DEFAULT 0                 -- If it should only show to users who are logged in (0 = False | 1 = True)
+);
+


### PR DESCRIPTION
This pull request updates and adds new api endpoints.

Updated files:
* `website.ts` - Updated to remove `body-parser` and add new URLs to CSP.
* `/api/register.ts` - Updated to add recaptcha.
* `init.sql` - Adds `announcements` table for annoncements.
* `permissions.json` - For announcement permissions (POST & DELETE)
* `/api/order.ts` - To add support for /api/order/checkout (For ordering a package) and /api/order/webhook (May change but it's for stripe to send a request to the server to give the client their package.

New files/endpoints:
* `/api/announcements.ts` - Allows you to view the announcements posted. (Or to create/delete announcements)
* `success.eta` - Success page for ordering
* `cancel.eta` - Cancel page for ordering (If you press the back button on stripe)

New packages added:
* `stripe` - For orders.
* `node-fetch` - For fetching results from a site (Used for recaptcha)

If there are any bugs with this PR, please let me know so I can fix them.